### PR TITLE
Initial support for nuget

### DIFF
--- a/Gundi/src/Gundi.Attributes/Gundi.Attributes.csproj
+++ b/Gundi/src/Gundi.Attributes/Gundi.Attributes.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Gundi</RootNamespace>
@@ -11,6 +12,9 @@
 
     <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="System.Text.Json" Version="6.0.2" />
+      <!-- Used by Gundi itself, need to be exposed by runtime lib to resolve nuget dependencies correctly -->
+      <PackageReference Include="Scriban" Version="5.4.3" />
     </ItemGroup>
 
 </Project>

--- a/Gundi/src/Gundi.Attributes/IsExternalInit.cs
+++ b/Gundi/src/Gundi.Attributes/IsExternalInit.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel;
+
+// Support for records in .netstandard 2.0
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal class IsExternalInit { }

--- a/Gundi/src/Gundi/AnalyzerResult.cs
+++ b/Gundi/src/Gundi/AnalyzerResult.cs
@@ -10,7 +10,7 @@ internal record AnalyzerResult<T>(IReadOnlyCollection<Diagnostic> Diagnostics, T
 
 internal static class AnalyzerResult
 {
-    public static AnalyzerResult<T> NoDiagnose<T>(T value) => new(ArraySegment<Diagnostic>.Empty, value);
+    public static AnalyzerResult<T> NoDiagnose<T>(T value) => new(Array.Empty<Diagnostic>(), value);
 
     public static AnalyzerResult<T> Compose<T1, T2, T>(AnalyzerResult<T1> a1, AnalyzerResult<T2> a2,
         Func<T1, T2, T> construct)

--- a/Gundi/src/Gundi/Gundi.csproj
+++ b/Gundi/src/Gundi/Gundi.csproj
@@ -1,23 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IncludeBuiltOutput>false</IncludeBuiltOutput>
         <WarningsAsErrors>Nullable</WarningsAsErrors>
-        <Description>Discrimated union source generator</Description>
+        <Description>The discriminated union source generator</Description>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" PrivateAssets="all" />
-        <PackageReference Include="Scriban" Version="5.4.1" GeneratePathProperty="true" PrivateAssets="all" />
+        <!-- It's used by Gundi.Attributes but it needs to displayed to generate nuget's dependencies -->
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="System.Text.Json" Version="6.0.2" />
+        <!-- Used only by Gundi project and it needs to be copy if referenced directly -->
+        <PackageReference Include="Scriban" Version="5.4.3" GeneratePathProperty="true" />
     </ItemGroup>
 
     <ItemGroup>
+        <None Include="../../../README.md" Pack="true" PackagePath="\" />
         <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-        <None Include="$(OutputPath)\Gundi.Attributes.dll" Pack="true" PackagePath="lib\net6.0" Visible="true" />
+        <None Include="$(OutputPath)\Gundi.Attributes.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="true" />
     </ItemGroup>
 
     <ItemGroup>
@@ -35,7 +42,7 @@
 
     <Target Name="GetDependencyTargetPaths">
         <ItemGroup>
-            <TargetPathWithTargetPlatformMoniker Include="$(PKGScriban)\lib\net6.0\Scriban.dll" IncludeRuntimeDependency="false" />
+            <TargetPathWithTargetPlatformMoniker Include="$(PKGScriban)\lib\netstandard2.0\Scriban.dll" IncludeRuntimeDependency="false" />
         </ItemGroup>
     </Target>
 

--- a/Gundi/src/Gundi/IsExternalInit.cs
+++ b/Gundi/src/Gundi/IsExternalInit.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel;
+
+// Support for records in .netstandard 2.0
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal class IsExternalInit { }

--- a/Gundi/src/Gundi/StringExtensions.cs
+++ b/Gundi/src/Gundi/StringExtensions.cs
@@ -7,6 +7,6 @@ internal static class StringExtensions
         {
             null => throw new ArgumentNullException(nameof(input)),
             "" => throw new ArgumentException($"{nameof(input)} cannot be empty", nameof(input)),
-            _ => string.Concat(input[0].ToString().ToUpper(), input.AsSpan(1))
+            _ => string.Concat(input[0].ToString().ToUpper(), input.AsSpan(1).ToString())
         };
 }

--- a/Gundi/tests/Gundi.Tests/Gundi.Tests.csproj
+++ b/Gundi/tests/Gundi.Tests/Gundi.Tests.csproj
@@ -21,7 +21,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Moved targeting to .netstandard2.0
- Fixed NuGet dependencies resolving (no need for coping of dependency .dll into the pack)